### PR TITLE
Simplify client & server launching

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    publicRuntimeConfig: {
+        SERVER_URL: 'http://localhost:9002',
+    },
+}

--- a/client/package.json
+++ b/client/package.json
@@ -2,7 +2,7 @@
   "name": "musiqparti-client",
   "version": "0.1.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 9001",
     "build": "next build",
     "start": "next start"
   },

--- a/client/src/pages/index.js
+++ b/client/src/pages/index.js
@@ -16,10 +16,11 @@ import { Footer } from "../components/Footer";
 import axios from "axios";
 import { useQuery } from "react-query";
 import { useRouter } from "next/router";
+import getConfig from "next/config";
 
-const Index = () => {
+const Index = (props) => {
   const { data, error, isLoading } = useQuery("hello", () => {
-    return axios.get("http://localhost:5000/spotify/hello");
+    return axios.get(`${props.SERVER_URL}/spotify/hello`); // TODO: Remove this.
   });
   const router = useRouter();
 
@@ -84,5 +85,16 @@ const Index = () => {
     </Container>
   );
 };
+
+export async function getStaticProps() {
+  const { publicRuntimeConfig } = getConfig();
+  const SERVER_URL = publicRuntimeConfig.SERVER_URL;
+
+  return {
+    props: {
+      SERVER_URL: SERVER_URL
+    },
+  }
+}
 
 export default Index;

--- a/client/src/pages/login.js
+++ b/client/src/pages/login.js
@@ -2,8 +2,9 @@ import { Link as ChakraLink, Flex, Button, Heading } from "@chakra-ui/react";
 import { Container } from "../components/Container";
 import axios from "axios";
 import { useState } from "react";
+import getConfig from "next/config";
 
-const Index = () => {
+const Index = (props) => {
   const [user, setUser] = useState({});
 
   console.log(user);
@@ -20,14 +21,14 @@ const Index = () => {
         </Heading>
       </Flex>
       <Flex>
-        <ChakraLink m={4} href="http://localhost:5000/spotify/login">
+        <ChakraLink m={4} href={`${props.SERVER_URL}/spotify/login`}>
           <Button as={ChakraLink}>Login</Button>
         </ChakraLink>
         <Button
           m={4}
           onClick={async () => {
             const { data } = await axios.get(
-              "http://localhost:5000/spotify/hello",
+              `${props.SERVER_URL}/spotify/hello`,
               {
                 withCredentials: true,
               }
@@ -41,7 +42,7 @@ const Index = () => {
           <Button
             m={4}
             onClick={async () => {
-              await axios.get("http://localhost:5000/spotify/logout", {
+              await axios.get(`${props.SERVER_URL}/spotify/logout`, {
                 withCredentials: true,
               });
               setUser({});
@@ -95,5 +96,17 @@ const Index = () => {
     </Container>
   );
 };
+
+export async function getStaticProps() {
+  const { publicRuntimeConfig } = getConfig();
+  const SERVER_URL = publicRuntimeConfig.SERVER_URL;
+
+  return {
+    props: {
+      SERVER_URL: SERVER_URL
+    },
+  }
+}
+
 
 export default Index;

--- a/server/.env
+++ b/server/.env
@@ -1,0 +1,6 @@
+DATABASE_URI=mongodb://localhost:27017
+PORT=9002
+CORS_ORIGIN=http://localhost:9001
+CLIENT_ID=<your spotify ID>
+CLIENT_SECRET=<your spotify client secret>
+REDIRECT_URI=localhost:9002


### PR DESCRIPTION
At a high-level, this PR makes it easier to launch the server and client, and to change either of their ports.

Detailed overview:
1) Provide more details in the server's `.env.example` file
2) Explicitly define the ports that the server and client run on
3) Define the server URL in an environment variable in the client, and reference this environment variable instead of hardcoding the URLS. For example: change `href="http://localhost:5000/spotify/login"` --> ``href={`${props.SERVER_URL}/spotify/login`}``.
